### PR TITLE
Don't recurse with modversion

### DIFF
--- a/test_main.c
+++ b/test_main.c
@@ -239,6 +239,33 @@ static void test_versioncheck(void)
     }
 }
 
+static void test_versionorder(void)
+{
+    // Scenario: liba depends on libc and libb
+    // Expect: modversion order is unaffected
+    config conf = newtest_(S("library version ordering"));
+    newfile_(&conf, S("/usr/lib/pkgconfig/a.pc"), S(
+        "Name: \n"
+        "Description: \n"
+        "Version: 1\n"
+        "Requires: c b\n"
+    ));
+    newfile_(&conf, S("/usr/lib/pkgconfig/b.pc"), S(
+        "Name: \n"
+        "Description: \n"
+        "Version: 2\n"
+    ));
+    newfile_(&conf, S("/usr/lib/pkgconfig/c.pc"), S(
+        "Name: \n"
+        "Description: \n"
+        "Version: 3\n"
+    ));
+    SHOULDPASS {
+        run(conf, S("--modversion"), S("a"), S("b"), S("c"), E);
+    }
+    EXPECT("1\n2\n3\n");
+}
+
 static void test_overrides(void)
 {
     config conf = newtest_(S("--{atleast,exact,max}-version"));
@@ -637,6 +664,7 @@ int main(void)
     test_dashdash();
     test_modversion();
     test_versioncheck();
+    test_versionorder();
     test_overrides();
     test_maximum_traverse_depth();
     test_private_transitive();

--- a/u-config.c
+++ b/u-config.c
@@ -1794,6 +1794,7 @@ static void uconfig(config *conf)
 
         } else if (s8equals(r.arg, S("-modversion"))) {
             modversion = 1;
+            proc->recursive = 0;
 
         } else if (s8equals(r.arg, S("-define-prefix"))) {
             proc->define_prefix = 1;


### PR DESCRIPTION
With recursive processing the output with --modversion flag may be incorrectly ordered as can be seen in the added test case. Recursive processing is also inconsistent with both pkg-config and pkgconf: if a package declares a version and requires a nonexistent package then both will print the version with the flag, while u-config will fail complaining that the transitively required package is missing.
