### PR TITLE
Emit processed packages in topological order 

### DIFF
--- a/test_main.c
+++ b/test_main.c
@@ -374,7 +374,7 @@ static void test_private_transitive(void)
     SHOULDPASS {
         run(conf, S("--libs"), S("--static"), S("a"), E);
     }
-    EXPECT("-la -lb -lc -lx\n");
+    EXPECT("-la -lx -lb -lc\n");
 }
 
 static void test_revealed_transitive(void)

--- a/test_main.c
+++ b/test_main.c
@@ -154,7 +154,7 @@ static void test_dashdash(void)
     SHOULDPASS {
         run(conf, S("--cflags"), S("--"), S("--foo"), S("--"), E);
     }
-    EXPECT("-Dfoo -Ddashdash\n");
+    EXPECT("-Ddashdash -Dfoo\n");
 }
 
 static void test_modversion(void)
@@ -374,7 +374,7 @@ static void test_private_transitive(void)
     SHOULDPASS {
         run(conf, S("--libs"), S("--static"), S("a"), E);
     }
-    EXPECT("-la -lx -lb -lc\n");
+    EXPECT("-la -lb -lc -lx\n");
 }
 
 static void test_revealed_transitive(void)
@@ -452,7 +452,7 @@ static void test_libsorder(void)
 {
     // Scenario: two packages link a common library
     // Expect: the common library is listed after both, other flags
-    //   maintain their first-seen position and de-duplicate the rest
+    //   are de-duplicated
     config conf = newtest_(S("library ordering"));
     newfile_(&conf, S("/usr/lib/pkgconfig/a.pc"), S(
         PCHDR
@@ -467,7 +467,7 @@ static void test_libsorder(void)
     SHOULDPASS {
         run(conf, S("--cflags"), S("--libs"), S("a b"), E);
     }
-    EXPECT("-DA -DGL -DB -L/opt/lib -pthread -mwindows -la -lb -lopengl32\n");
+    EXPECT("-DB -DGL -DA -L/opt/lib -pthread -mwindows -lb -la -lopengl32\n");
 }
 
 static void test_staticorder(void)

--- a/test_main.c
+++ b/test_main.c
@@ -154,7 +154,7 @@ static void test_dashdash(void)
     SHOULDPASS {
         run(conf, S("--cflags"), S("--"), S("--foo"), S("--"), E);
     }
-    EXPECT("-Ddashdash -Dfoo\n");
+    EXPECT("-Dfoo -Ddashdash\n");
 }
 
 static void test_modversion(void)
@@ -452,7 +452,7 @@ static void test_libsorder(void)
 {
     // Scenario: two packages link a common library
     // Expect: the common library is listed after both, other flags
-    //   are de-duplicated
+    //   maintain their first-seen position and de-duplicate the rest
     config conf = newtest_(S("library ordering"));
     newfile_(&conf, S("/usr/lib/pkgconfig/a.pc"), S(
         PCHDR
@@ -467,7 +467,7 @@ static void test_libsorder(void)
     SHOULDPASS {
         run(conf, S("--cflags"), S("--libs"), S("a b"), E);
     }
-    EXPECT("-DB -DGL -DA -L/opt/lib -pthread -mwindows -lb -la -lopengl32\n");
+    EXPECT("-DA -DGL -DB -L/opt/lib -pthread -mwindows -la -lb -lopengl32\n");
 }
 
 static void test_staticorder(void)

--- a/u-config.c
+++ b/u-config.c
@@ -1350,10 +1350,7 @@ static s8 joinargs(arena *a, s8 *args, size nargs, b32 recursive)
         versop op = 0;
 
         for (size i = nargs-1; i >= 0; i--) {
-            s8pair p = {0};
-            p.head = args[i];
-            while (p.head.len) {
-                p = lasttoken(p.head);
+            for (s8pair p = lasttoken(args[i]); p.tail.len; p = lasttoken(p.head)) {
                 s8 tok = p.tail;
 
                 if (op) {

--- a/u-config.c
+++ b/u-config.c
@@ -1542,16 +1542,16 @@ static void process(processor *proc, s8 arg, arena *perm)
                     failmaxrecurse(err, tok);
                 }
                 top++;
-                stack[top].arg = p->requiresprivate;
-                stack[top].last = 0;
-                stack[top].depth = depth;
-                stack[top].flags = 0;
-                stack[top].op = versop_ERR;
-                top++;
                 stack[top].arg = p->requires;
                 stack[top].last = 0;
                 stack[top].depth = depth;
                 stack[top].flags = flags & ~pkg_DIRECT;
+                stack[top].op = versop_ERR;
+                top++;
+                stack[top].arg = p->requiresprivate;
+                stack[top].last = 0;
+                stack[top].depth = depth;
+                stack[top].flags = 0;
                 stack[top].op = versop_ERR;
             }
         }


### PR DESCRIPTION
Fixes #6. By prepending a pkg to the list when it's popped off the stack we ensure that all of its dependencies are already processed, which means that the flags will be printed in the correct order.

This has the consequence that flags in the output are in reversed order compared to the input packages, i.e. the invocation

```
  pkg-config --libs a b
```

will result in

```
  -lb -la
```

assuming that there are no depenencies between liba and libb.