### PR TITLE
Add $PKG_CONFIG_SYSROOT_DIR for cross builds

### DIFF
--- a/main_posix.c
+++ b/main_posix.c
@@ -89,11 +89,6 @@ static filemap os_mapfile(os *ctx, arena *perm, s8 path)
     return r;
 }
 
-static b32 endswith_(s8 s, s8 suffix)
-{
-    return s.len>=suffix.len && s8equals(taketail(s, suffix.len), suffix);
-}
-
 static s8node *os_listing(os *ctx, arena *a, s8 path)
 {
     (void)ctx;
@@ -110,7 +105,7 @@ static s8node *os_listing(os *ctx, arena *a, s8 path)
     s8list files = {0};
     for (struct dirent *d; (d = readdir(handle));) {
         s8 name = s8fromcstr((u8 *)d->d_name);
-        if (endswith_(name, S(".pc"))) {
+        if (endswith(name, S(".pc"))) {
             s8 copy = news8(a, name.len);
             s8copy(copy, name);
             append(&files, copy, a);
@@ -177,6 +172,7 @@ int main(int argc, char **argv)
         conf->sys_libpath = S(PKG_CONFIG_SYSTEM_LIBRARY_PATH);
     }
     conf->top_builddir = s8getenv_("PKG_CONFIG_TOP_BUILD_DIR");
+    conf->sysrootdir   = s8getenv_("PKG_CONFIG_SYSROOT_DIR");
     conf->print_sysinc = s8getenv_("PKG_CONFIG_ALLOW_SYSTEM_CFLAGS");
     conf->print_syslib = s8getenv_("PKG_CONFIG_ALLOW_SYSTEM_LIBS");
 

--- a/main_test.c
+++ b/main_test.c
@@ -634,7 +634,7 @@ static void test_sysrootdir(arena a)
     // pkgconf, both of which have fundamentally flawed behavior, though
     // pkg-config is closer to being correct. Only -I and -L of packages
     // discovered under the "fake" sysroot are affected, e.g. libbar.
-    config conf = newtest_(a, S("exclude syspaths"));
+    config conf = newtest_(a, S("pc_sysrootdir"));
     conf.envpath = S("/tmp/usr/lib/pkgconfig");
     conf.sysrootdir = S("/tmp");  // i.e. DESTDIR=/tmp
     newfile_(&conf, S("/usr/lib/pkgconfig/foo.pc"), S(

--- a/main_test.c
+++ b/main_test.c
@@ -613,6 +613,81 @@ static void test_syspaths(arena a)
     EXPECT("-DEXAMPLE -L/usr/lib -lexample\n");
 }
 
+static void test_sysrootdir(arena a)
+{
+    // Scenario: a package is half-installed into a DESTDIR
+    // Expect: -I and -L adjusted, other path prefixes untouched
+    //
+    // This exists to support cross-compilation. Dependencies are never
+    // to be installed on the build system, but must still be available
+    // as dependencies in their temporary DESTDIR. The same .pc files
+    // will be used by the cross toolchain (now) and native toolchain
+    // (later). The cross build system sets PKG_CONFIG_SYSROOT_DIR to
+    // direct pkg-config to modify -I and -L from DESTDIR-located
+    // packages to match the current, temporary reality.
+    //
+    // If a package came from DESTDIR, it matters not how its -I or -L
+    // are constructed, whether hardcoded or derived from ${prefix}. If
+    // it's an absolute path then it requires modification.
+    //
+    // The expected output matches neither the original pkg-config nor
+    // pkgconf, both of which have fundamentally flawed behavior, though
+    // pkg-config is closer to being correct. Only -I and -L of packages
+    // discovered under the "fake" sysroot are affected, e.g. libbar.
+    config conf = newtest_(a, S("exclude syspaths"));
+    conf.envpath = S("/tmp/usr/lib/pkgconfig");
+    conf.sysrootdir = S("/tmp");  // i.e. DESTDIR=/tmp
+    newfile_(&conf, S("/usr/lib/pkgconfig/foo.pc"), S(
+        PCHDR
+        "prefix=/usr\n"
+        "Cflags: -DFOO=${prefix}/share/foo -I${prefix}/include\n"
+        "Libs: -L${prefix}/lib -lfoo\n"
+    ));
+    newfile_(&conf, S("/tmp/usr/lib/pkgconfig/bar.pc"), S(
+        PCHDR
+        "prefix=/usr\n"
+        "Cflags: -DBAR=${prefix}/share/bar -I${prefix}/include\n"
+        "Libs: -L${prefix}/lib -lbar\n"
+    ));
+
+    SHOULDPASS {
+        run(conf, S("--variable"), S("pc_sysrootdir"), S("pkg-config"), E);
+    }
+    EXPECT("/\n");  // not under $PKG_CONFIG_SYSROOT_DIR
+
+    SHOULDPASS {
+        run(conf, S("--variable"), S("pc_sysrootdir"), S("foo"), E);
+    }
+    EXPECT("/\n");  // not under $PKG_CONFIG_SYSROOT_DIR
+
+    SHOULDPASS {
+        run(
+            conf,
+            S("--variable"), S("pc_sysrootdir"),
+            // NOTE: pkgconf modifies absolute path arguments, too, and
+            // so fails to find bar.pc in this scenario.
+            S("/tmp/usr/lib/pkgconfig/bar.pc"),
+            E
+        );
+    }
+    EXPECT("/tmp\n");
+
+    // The build system adds DESTDIR to PKG_CONFIG_PATH because needed
+    // .pc files are located there, then sets PKG_CONFIG_SYSROOT_DIR to
+    // adjust the -I and -L flags produced by DESTDIR-located packages.
+    // Because libfoo is installed, not in DESTDIR, it is unaffected by
+    // this configuration, but libbar -I and -L are affected. Hard-coded
+    // paths to data are unaffected, because they used at run-time, not
+    // while the program is still located in the DESTDIR.
+    SHOULDPASS {
+        run(conf, S("--cflags"), S("--libs"), S("foo"), S("bar"), E);
+    }
+    EXPECT(
+        "-DFOO=/usr/share/foo -DBAR=/usr/share/bar -I/tmp/usr/include "
+        "-lfoo -L/tmp/usr/lib -lbar\n"
+    );
+}
+
 static void test_libsorder(arena a)
 {
     // Scenario: two packages link a common library
@@ -1017,6 +1092,7 @@ int main(void)
     test_private_transitive(a);
     test_revealed_transitive(a);
     test_syspaths(a);
+    test_sysrootdir(a);
     test_libsorder(a);
     test_staticorder(a);
     test_windows(a);

--- a/main_wasm.c
+++ b/main_wasm.c
@@ -274,6 +274,8 @@ void _start(void)
             conf.sys_incpath = value;
         } else if (s8equals(name, S("PKG_CONFIG_SYSTEM_LIBRARY_PATH"))) {
             conf.sys_libpath = value;
+        } else if (s8equals(name, S("PKG_CONFIG_SYSROOT_DIR"))) {
+            conf.sysrootdir = value;
         } else if (s8equals(name, S("PKG_CONFIG_ALLOW_SYSTEM_CFLAGS"))) {
             conf.print_sysinc = value;
         } else if (s8equals(name, S("PKG_CONFIG_ALLOW_SYSTEM_LIBS"))) {

--- a/main_windows.c
+++ b/main_windows.c
@@ -346,6 +346,7 @@ void mainCRTStartup(void)
     conf->top_builddir = fromenv_(perm, L"PKG_CONFIG_TOP_BUILD_DIR");
     conf->sys_incpath  = conf->pc_sysincpath;
     conf->sys_libpath  = conf->pc_syslibpath;
+    conf->sysrootdir   = fromenv_(perm, L"PKG_CONFIG_SYSROOT_DIR");
     conf->print_sysinc = fromenv_(perm, L"PKG_CONFIG_ALLOW_SYSTEM_CFLAGS");
     conf->print_syslib = fromenv_(perm, L"PKG_CONFIG_ALLOW_SYSTEM_LIBS");
 

--- a/src/linux_noarch.c
+++ b/src/linux_noarch.c
@@ -189,6 +189,8 @@ static i32 os_main(i32 argc, u8 **argv, u8 **envp)
             conf->sys_incpath = value;
         } else if (s8equals(name, S("PKG_CONFIG_SYSTEM_LIBRARY_PATH"))) {
             conf->sys_libpath = value;
+        } else if (s8equals(name, S("PKG_CONFIG_SYSROOT_DIR"))) {
+            conf->sysrootdir = value;
         } else if (s8equals(name, S("PKG_CONFIG_ALLOW_SYSTEM_CFLAGS"))) {
             conf->print_sysinc = value;
         } else if (s8equals(name, S("PKG_CONFIG_ALLOW_SYSTEM_LIBS"))) {

--- a/u-config.1
+++ b/u-config.1
@@ -58,6 +58,9 @@ supports all the important pkg-config run-time environment variables. To see
 which are supported, use the
 .Fl \-help
 option.
+One important difference:
+.Ev PKG_CONFIG_SYSROOT_DIR
+only affects -I and -L flags, and only for .pc files found under that path.
 .
 .Sh EXAMPLES
 .Bd -literal


### PR DESCRIPTION
I came across this:  
https://wiki.glaucuslinux.org/build-notes/u-config/

Since it's a wiki, here's the text as of this writing:  
https://github.com/glaucuslinux/wiki/blob/f1ac9b5e/src/content/docs/build-notes/u-config.md

Which got me thinking about `PKG_CONFIG_SYSROOT_DIR` so that u-config could handle more special cases. It took some time for me to understand how it's intended to work (e.g. for `DESTDIR` and cross builds), especially because the behavior I was seeing from pkg-config and pkgconf didn't make sense. I think I got a handle on it, and how it ought to work. I have a little explanation in the commit message, and a test exercising the edge cases I imagine. Especially since I'm striking off in a new direction, I'm looking for feedback on the behavior.

I suspect some builds depend on either the particular pkg-config behavior or the pkgconf behavior, and the latter even has a special option to support the former (`PKG_CONFIG_FDO_SYSROOT_RULES`). Most of the instances of `pc_sysrootdir` I could find were confused, not understanding the purpose, such as here in Wayland:

https://lore.freedesktop.org/wayland-devel/1400512363-30116-5-git-send-email-thierry.reding@gmail.com/

Understandable, because this feature is not named well. I also wondered if `pc_sysrootdir` shouldn't be set when it doesn't apply, and this `.pc` convinced me of a use case:

https://gitlab.freedesktop.org/xorg/proto/xcbproto/-/blob/master/xcb-proto.pc.in

This particular `.pc` does nothing, but there's a hint of using `pc_sysrootdir` to locate special build-time resources like a Python installation, e.g. to extend the `-I`/`-L` modifications to more places.

* * *

This implementation behaves differently from pkg-config and pkgconf, and by doing so better supports the intended purpose of this feature. It is closer in behavior to pkg-config.

For example, suppose we are cross-compiling a program, foo-cli, that depends on libfoo, which places its run-time data at some given, fixed path under ${prefix}/share:

    $ make -C libfoo install
    cc -c lib.c
    cc -shared -o libfoo.so lib.o
    cp libfoo.so /usr/lib/
    cp share/libfoo.bin /usr/share/
    cp libfoo.pc /usr/lib/pkgconfig/

    $ make -C foo-cli install
    cc -c -DFOO_DATADIR=/usr/share -I/usr/include main.c
    cc -L/usr/lib -o foo-cli main.o -lfoo
    cp foo-cli /usr/bin/

When cross-compiling we might stage this in a DESTDIR for packaging, and then build foo-cli against the staged libfoo:

    $ make -C libfoo install DESTDIR=/build
    cross-cc -c lib.c
    cross-cc -shared -o libfoo.so lib.o
    cp libfoo.so /build/usr/lib/
    cp share/libfoo.bin /build/usr/share/
    cp libfoo.pc /build/usr/lib/pkgconfig/

    $ make -C foo-cli install DESTDIR=/build
    cross-cc -c -DFOO_DATADIR=/usr/share -I/build/usr/include main.c
    cross-cc -L/build/usr/lib -o foo-cli main.o -lfoo
    cp foo-cli /build/usr/bin/

Notice that when building foo-cli both -I and -L needed to prepend the DESTDIR so that the cross-toolchain could find the library. Also notice that the data path is untouched because this is a run-time path, not a build-time path. The DESTDIR will not exist at run time. A .pc file will derive these paths from ${prefix}, but only -I and -L should be affected when building against DESTDIR. The hard-coded data path should never be affected by DESTDIR. A possible libfoo.pc:

    prefix = /usr
    Name: libfoo
    Description: The foo library
    Version: 1
    Cflags: -DFOO_DATADIR=${prefix}/share -I${prefix}/include
    Libs: -L${prefix}/lib -lfoo

So then with PKG_CONFIG_SYSROOT_DIR we ought to get:

    $ export PKG_CONFIG_PATH=/build/usr/lib/pkgconfig
    $ export PKG_CONFIG_SYSROOT_DIR=/build
    $ cross-pkg-config --cflags --libs libfoo
    -DFOO_DATADIR=/usr/share -I/build/usr/include -L/build/usr/lib -lfoo

When foo-cli runs later on its native system, the data will be in its proper /usr/share, not under the /build DESTDIR back on the build host.

If foo-cli were to depend on a second library not installed in DESTDIR, instead installed in, say, the cross toolchain sysroot, its pkg-config configuration must be unaffected by PKG_CONFIG_SYSROOT_DIR because it is not located in the DESTDIR and so does not require adjustment.